### PR TITLE
JQuery problems over ssl

### DIFF
--- a/categories.php
+++ b/categories.php
@@ -126,5 +126,6 @@ if (isset($category_error)) {
 $smarty->assign('haserror', $haserror);
 $smarty->assign('isadmin', $_SESSION["admin"]);
 $smarty->assign('opt', $smarty->opt());
+$smarty->assign('protocol', effectiveProtocol());
 $smarty->display('categories.tpl');
 ?>

--- a/event.php
+++ b/event.php
@@ -213,6 +213,7 @@ try {
 		$smarty->assign('eventid', $eventid);
 	}
 	$smarty->assign('userid', $userid);
+	$smarty->assign('protocol', effectiveProtocol());
 	$smarty->display('event.tpl');
 }
 catch (PDOException $e) {

--- a/families.php
+++ b/families.php
@@ -185,6 +185,7 @@ try {
 	if (isset($message)) {
 		$smarty->assign('message', $message);
 	}
+	$smarty->assign('protocol', effectiveProtocol());
 	$smarty->display('families.tpl');
 }
 catch (PDOException $e) {

--- a/forgot.php
+++ b/forgot.php
@@ -57,6 +57,7 @@ if (isset($_POST["action"]) && $_POST["action"] == "forgot") {
 		}
 		$smarty->assign('action', $_POST["action"]);
 		$smarty->assign('username', $username);
+		$smarty->assign('protocol', effectiveProtocol());
 		$smarty->display('forgot.tpl');
 	}
 	catch (PDOException $e) {

--- a/includes/funcLib.php
+++ b/includes/funcLib.php
@@ -207,4 +207,14 @@ function fixForJavaScript($s) {
 	$s = str_replace("\n","<br />",$s);
 	return $s;
 }
+
+function effectiveProtocol() {
+	if( (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERVER['SERVER_PORT'] == 443 ){
+		return "https:";
+	}
+	else {
+		return "http:";
+	}
+}
+
 ?>

--- a/index.php
+++ b/index.php
@@ -311,6 +311,7 @@ $smarty->assign('shoppees', $shoppees);
 $smarty->assign('prospects', $prospects);
 $smarty->assign('messages', $messages);
 $smarty->assign('events', $events);
+$smarty->assign('protocol', effectiveProtocol());
 if (isset($pending)) {
 	$smarty->assign('pending', $pending);
 }

--- a/item.php
+++ b/item.php
@@ -299,5 +299,6 @@ $smarty->assign('image_filename', $image_filename);
 $smarty->assign('comment', $comment);
 $smarty->assign('categories', $categories);
 $smarty->assign('ranks', $ranks);
+$smarty->assign('protocol', effectiveProtocol());
 $smarty->display('item.tpl');
 ?>

--- a/login.php
+++ b/login.php
@@ -50,6 +50,7 @@ if (!empty($_POST["username"])) {
 	}
 
 	$smarty->assign('username', $username);
+	$smarty->assign('protocol', effectiveProtocol());
 	$smarty->display('login.tpl');
 }
 else {

--- a/message.php
+++ b/message.php
@@ -58,6 +58,7 @@ try {
 	$smarty->assign('recipients', $recipients);
 	$smarty->assign('rcount', $rcount);
 	$smarty->assign('userid', $userid);
+	$smarty->assign('protocol', effectiveProtocol());
 	$smarty->display('message.tpl');
 }
 catch (PDOException $e) {

--- a/mylist.php
+++ b/mylist.php
@@ -81,6 +81,7 @@ try {
 	$smarty->assign('totalprice', formatPrice($totalprice, $opt));
 	$smarty->assign('itemcount', $itemcount);
 	$smarty->assign('userid', $userid);
+	$smarty->assign('protocol', effectiveProtocol());
 	$smarty->display('mylist.tpl');
 }
 catch (PDOException $e) {

--- a/profile.php
+++ b/profile.php
@@ -89,6 +89,7 @@ try {
 		$smarty->assign('email', $row["email"]);
 		$smarty->assign('email_msgs', $row["email_msgs"]);
 		$smarty->assign('comment', $row["comment"]);
+		$smarty->assign('protocol', effectiveProtocol());
 		$smarty->display('profile.tpl');
 	}
 	else {

--- a/ranks.php
+++ b/ranks.php
@@ -162,5 +162,6 @@ if (isset($rendered_error)) {
 }
 $smarty->assign('ranking', $_GET["ranking"]);
 $smarty->assign('haserror', $haserror);
+$smarty->assign('protocol', effectiveProtocol());
 $smarty->display('ranks.tpl');
 ?>

--- a/receive.php
+++ b/receive.php
@@ -108,6 +108,7 @@ try {
 	$smarty->assign('quantity', $quantity);
 	$smarty->assign('itemid', $itemid);
 	$smarty->assign('userid', $userid);
+	$smarty->assign('protocol', effectiveProtocol());
 	$smarty->display('receive.tpl');
 }
 catch (PDOException $e) {

--- a/shop.php
+++ b/shop.php
@@ -220,6 +220,7 @@ $smarty->assign('ufullname', $ufullname);
 $smarty->assign('shopfor', $shopfor);
 $smarty->assign('shoprows', $shoprows);
 $smarty->assign('userid', $userid);
+$smarty->assign('protocol', effectiveProtocol());
 if (isset($message)) {
 	$smarty->assign('message', $message);
 }

--- a/shoplist.php
+++ b/shoplist.php
@@ -82,6 +82,7 @@ try {
 	$smarty->assign('totalprice', formatPrice($totalprice, $opt));
 	$smarty->assign('itemcount', $itemcount);
 	$smarty->assign('userid', $userid);
+	$smarty->assign('protocol', effectiveProtocol());
 	$smarty->display('shoplist.tpl');
 }
 catch (PDOException $e) {

--- a/signup.php
+++ b/signup.php
@@ -106,6 +106,7 @@ $smarty->assign('email', $email);
 $smarty->assign('familyid', $familyid);
 $smarty->assign('familycount', count($families));
 $smarty->assign('action', $_POST["action"]);
+$smarty->assign('protocol', effectiveProtocol());
 if (isset($error)) {
 	$smarty->assign('error', $error);
 }

--- a/templates/categories.tpl
+++ b/templates/categories.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<script src="js/jquery.validate.min.js"></script>
 	<script src="js/giftreg.js"></script>

--- a/templates/event.tpl
+++ b/templates/event.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<link href="datepicker/css/datepicker.css" rel="stylesheet">
 	<script src="datepicker/js/bootstrap-datepicker.js"></script>

--- a/templates/families.tpl
+++ b/templates/families.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<script src="js/jquery.validate.min.js"></script>
 	<script src="js/giftreg.js"></script>

--- a/templates/forgot.tpl
+++ b/templates/forgot.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<script src="js/jquery.validate.min.js"></script>
 	<script src="js/giftreg.js"></script>

--- a/templates/home.tpl
+++ b/templates/home.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<link href="lightbox/css/jquery.lightbox-0.5.css" rel="stylesheet">
 	<script src="lightbox/js/jquery.lightbox-0.5.min.js"></script>

--- a/templates/item.tpl
+++ b/templates/item.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<script src="js/jquery.validate.min.js"></script>
 	<script src="js/giftreg.js"></script>

--- a/templates/login.tpl
+++ b/templates/login.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<script src="js/jquery.validate.min.js"></script>
 	<script src="js/giftreg.js"></script>

--- a/templates/message.tpl
+++ b/templates/message.tpl
@@ -57,7 +57,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 			</div>
 		</div>
 	</div>
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/templates/mylist.tpl
+++ b/templates/mylist.tpl
@@ -87,7 +87,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		</div>
 	</div>
 
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/templates/profile.tpl
+++ b/templates/profile.tpl
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<script src="js/jquery.validate.min.js"></script>
 	<script src="js/giftreg.js"></script>

--- a/templates/ranks.tpl
+++ b/templates/ranks.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<script src="js/jquery.validate.min.js"></script>
 	<script src="js/giftreg.js"></script>

--- a/templates/receive.tpl
+++ b/templates/receive.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<script src="js/jquery.validate.min.js"></script>
 	<script src="js/giftreg.js"></script>

--- a/templates/shop.tpl
+++ b/templates/shop.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<link href="lightbox/css/jquery.lightbox-0.5.css" rel="stylesheet">
 	<script src="lightbox/js/jquery.lightbox-0.5.min.js"></script>

--- a/templates/shoplist.tpl
+++ b/templates/shoplist.tpl
@@ -82,7 +82,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 		</div>
 	</div>
 
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/templates/signup.tpl
+++ b/templates/signup.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<script src="js/jquery.validate.min.js"></script>
 	<script src="js/giftreg.js"></script>

--- a/templates/users.tpl
+++ b/templates/users.tpl
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="{$protocol}//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script src="bootstrap/js/bootstrap.min.js"></script>
 	<script src="js/jquery.validate.min.js"></script>
 	<script src="js/giftreg.js"></script>

--- a/users.php
+++ b/users.php
@@ -221,5 +221,6 @@ if (isset($message)) {
 	$smarty->assign('message', $message);
 }
 $smarty->assign('userid', $userid);
+$smarty->assign('protocol', effectiveProtocol());
 $smarty->display('users.tpl');
 ?>


### PR DESCRIPTION
Some browsers are giving mixed content warnings and not downloading jquery when the app is hosted over ssl.  Jquery is being downloaded over http, when it should be https in these cases.

Added a function effectiveProtocol() to return http/https and used that in the templates for the ajax.googleapis.com address.